### PR TITLE
Prep for publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/google/file-header"
 keywords = ["license", "header"]
+categories = ["development-tools"]
+rust-version = "1.56.0"
 
 [dependencies]
 thiserror = "1.0.44"
@@ -13,6 +15,9 @@ crossbeam = "0.8.2"
 walkdir = "2.3.3"
 lazy_static = { version = "1.4.0", optional = true }
 license = { version = "3.1.1", optional = true }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [dev-dependencies]
 tempfile = "3.7.0"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ file-header
 ==========
 A Rust library to check for and add headers to files.
 
-When the `spdx` feature is enabled (which is on by default), it supports using
-any [SPDX](https://spdx.dev/) license known to
-the [`license` crate](https://crates.io/crates/license) as headers.
+A _header_ can be any arbitrary text, but we provide an `spdx` feature, which when enabled
+allows usage of any [SPDX](https://spdx.dev/) license known to the [`license` crate](https://crates.io/crates/license) as headers. For easy use of 
+this feature, we have already defined structs to support some commonly used licenses:
+* [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) 
+* [MIT](https://spdx.org/licenses/MIT.html)
+* [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)
+* [GPL-3.0-Only](https://spdx.org/licenses/GPL-3.0-only.html)
+* [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html)
+* [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html)

--- a/src/license/spdx/mod.rs
+++ b/src/license/spdx/mod.rs
@@ -346,8 +346,8 @@ lazy_static! {
 }
 lazy_static! {
     /// GPL 3.0 license
-    pub static ref GPL_3_0: SpdxLicense<Gpl3Tokens> = SpdxLicense ::new(
-        Box::new(license::licenses::Gpl3_0),
+    pub static ref GPL_3_0_ONLY: SpdxLicense<Gpl3Tokens> = SpdxLicense ::new(
+        Box::new(license::licenses::Gpl3_0Only),
          "GNU General Public License".to_string(),
          10
     );

--- a/src/license/spdx/tests.rs
+++ b/src/license/spdx/tests.rs
@@ -40,7 +40,7 @@ fn mit() {
 
 #[test]
 fn gpl3() {
-    let license_header = GPL_3_0.build_header(YearCopyrightOwnerValue::new(
+    let license_header = GPL_3_0_ONLY.build_header(YearCopyrightOwnerValue::new(
         2023,
         "Some copyright holder".to_string(),
     ));


### PR DESCRIPTION
Modified Cargo.toml for publishing to crates.io + updated GPL-3.0 to GPL-3.0-ONLY (GPL3.0 is marked as deprecated on spdx). 