### PR TITLE
Update version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "file-header"
 description = "Rust library to check for and add headers to files"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/google/file-header"
 keywords = ["license", "header"]
 categories = ["development-tools"]
 rust-version = "1.65.0"
+documentation = "https://docs.rs/crate/file-header"
 
 [dependencies]
 thiserror = "1.0.44"
@@ -24,5 +25,6 @@ tempfile = "3.7.0"
 globset = "0.4.11"
 
 [features]
-default = ["spdx"]
+default = ["spdx", "license-offline"]
+license-offline = ["license/offline"]
 spdx = ["dep:license", "dep:lazy_static"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 file-header
 ==========
+[![Crates.io](https://img.shields.io/crates/v/file-header)](https://crates.io/crates/file-header) [![Docs](https://docs.rs/file-header/badge.svg)](https://docs.rs/file-header)
+
 A Rust library to check for and add headers to files.
 
 A _header_ can be any arbitrary text, but we provide an `spdx` feature, which when enabled
@@ -11,3 +13,9 @@ this feature, we have already defined structs to support some commonly used lice
 * [GPL-3.0-Only](https://spdx.org/licenses/GPL-3.0-only.html)
 * [EPL-2.0](https://spdx.org/licenses/EPL-2.0.html)
 * [MPL-2.0](https://spdx.org/licenses/MPL-2.0.html)
+
+By default, this crate enables a `license-offline` feature to build the [`license` crate](https://crates.io/crates/license) offline; if you want 
+to download the [latest licenses](https://github.com/spdx) when building, 
+you will have to disable default features and enable only the `spdx` feature. 
+
+If you are looking for a tool (rather than a library) that can add license headers, check out [addlicense](https://github.com/google/addlicense).


### PR DESCRIPTION
Added changes to: 

- Introduce license-offline feature to build the license crate offline by default . 
- Update Cargo.toml to link documentation. 
- README updates: details about the license-offline feature and added shields. 