### PR TITLE
Adding functions and methods for deleting headers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "file-header"
 description = "Rust library to check for and add headers to files"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/google/file-header"
@@ -11,18 +11,18 @@ rust-version = "1.65.0"
 documentation = "https://docs.rs/crate/file-header"
 
 [dependencies]
-thiserror = "1.0.44"
 crossbeam = "0.8.2"
-walkdir = "2.3.3"
 lazy_static = { version = "1.4.0", optional = true }
-license = { version = "3.1.1", optional = true}
+license = { version = "3.1.1", optional = true }
+thiserror = "1.0.44"
+walkdir = "2.3.3"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
 
 [dev-dependencies]
-tempfile = "3.7.0"
 globset = "0.4.11"
+tempfile = "3.7.0"
 
 [features]
 default = ["spdx", "license-offline"]


### PR DESCRIPTION
This adds the necessary functions and methods to delete headers from a workspace.

The primary use case for this is updating the license statements for example in a private repository, or if switching to a new license.